### PR TITLE
Add Go vanity import for agent-gate

### DIFF
--- a/cmd/builder/main.go
+++ b/cmd/builder/main.go
@@ -32,5 +32,39 @@ func main() {
 	}
 
 	fmt.Println("✓ Generated index.html")
+
+	// Generate Go vanity import pages
+	if err := generateVanityPage("agent-gate", "https://github.com/agoodkind/agent-gate"); err != nil {
+		fmt.Fprintf(os.Stderr, "Error generating vanity page: %v\n", err)
+		os.Exit(1)
+	}
+
 	fmt.Println("Build complete!")
+}
+
+// generateVanityPage writes dist/<pkg>/index.html with the go-import meta tag
+// needed for `go install goodkind.io/<pkg>@latest` to resolve to GitHub.
+func generateVanityPage(pkg, repoURL string) error {
+	dir := filepath.Join("dist", pkg)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return err
+	}
+	content := fmt.Sprintf(`<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="go-import" content="goodkind.io/%s git %s">
+<meta http-equiv="refresh" content="0; url=%s">
+</head>
+<body>
+Redirecting to <a href="%s">%s</a>
+</body>
+</html>
+`, pkg, repoURL, repoURL, repoURL, repoURL)
+	path := filepath.Join(dir, "index.html")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		return err
+	}
+	fmt.Printf("✓ Generated %s/index.html\n", pkg)
+	return nil
 }


### PR DESCRIPTION
## Summary

- Adds `generateVanityPage()` to `cmd/builder/main.go`
- Generates `dist/agent-gate/index.html` at build time with `<meta name="go-import">` pointing to `github.com/agoodkind/agent-gate`
- Includes HTTP refresh redirect to GitHub for browsers
- Enables `go install goodkind.io/agent-gate@latest` to resolve correctly

## Test plan

- [ ] After merge and deploy, `curl "https://goodkind.io/agent-gate?go-get=1"` should return HTML with `go-import` meta tag
- [ ] `go install goodkind.io/agent-gate@latest` should succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)