### PR TITLE
Fix: grant deployments:write to build-and-deploy job

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,9 @@ on: ["push"]
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      deployments: write
     outputs:
       deployment-url: ${{ steps.deploy.outputs.deployment-url }}
       pages-deployment-alias-url: ${{ steps.deploy.outputs.alias }}


### PR DESCRIPTION
## Summary

- Adds `permissions: deployments: write` to the `build-and-deploy` job
- Without this, `wrangler-action` logs `Creating Github Deployment failed` because the default `GITHUB_TOKEN` only has `deployments: read`
- GitHub Deployments to the `preview` environment are required by the branch ruleset, so Dependabot PRs cannot auto-merge without this fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)