### PR TITLE
Add Go vanity import for agent-gate

### DIFF
--- a/cmd/builder/main.go
+++ b/cmd/builder/main.go
@@ -2,12 +2,17 @@ package main
 
 import (
 	"context"
+	_ "embed"
 	"fmt"
 	"os"
 	"path/filepath"
+	"text/template"
 
 	"goodkind.io/views/pages"
 )
+
+//go:embed templates/vanity.html
+var vanityTmpl string
 
 func main() {
 	// Create dist directory
@@ -32,5 +37,39 @@ func main() {
 	}
 
 	fmt.Println("✓ Generated index.html")
+
+	if err := generateVanityPage("agent-gate", "https://github.com/agoodkind/agent-gate"); err != nil {
+		fmt.Fprintf(os.Stderr, "Error generating vanity page: %v\n", err)
+		os.Exit(1)
+	}
+
 	fmt.Println("Build complete!")
+}
+
+// generateVanityPage writes dist/<pkg>/index.html from assets/vanity.html,
+// enabling `go install goodkind.io/<pkg>@latest` to resolve to GitHub.
+func generateVanityPage(pkg, repoURL string) error {
+	dir := filepath.Join("dist", pkg)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return err
+	}
+
+	tmpl, err := template.New("vanity").Parse(vanityTmpl)
+	if err != nil {
+		return err
+	}
+
+	path := filepath.Join(dir, "index.html")
+	out, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	if err := tmpl.Execute(out, struct{ Pkg, RepoURL string }{pkg, repoURL}); err != nil {
+		return err
+	}
+
+	fmt.Printf("✓ Generated %s/index.html\n", pkg)
+	return nil
 }

--- a/cmd/builder/templates/vanity.html
+++ b/cmd/builder/templates/vanity.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="go-import" content="goodkind.io/{{.Pkg}} git {{.RepoURL}}">
+<meta http-equiv="refresh" content="0; url={{.RepoURL}}">
+</head>
+<body>
+Redirecting to <a href="{{.RepoURL}}">{{.RepoURL}}</a>
+</body>
+</html>


### PR DESCRIPTION
Generates `dist/agent-gate/index.html` during build with the `go-import` meta tag, enabling `go install goodkind.io/agent-gate@latest`.

HTML lives in `cmd/builder/templates/vanity.html` (embedded via `//go:embed`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)