### PR TITLE
feat: Pages Function for Go vanity imports

### DIFF
--- a/functions/[[catchall]].ts
+++ b/functions/[[catchall]].ts
@@ -1,0 +1,39 @@
+const DOMAIN = "goodkind.io";
+const GH_USER = "agoodkind";
+
+interface Env {
+  ASSETS: Fetcher;
+}
+
+export const onRequest: PagesFunction<Env> = async (context) => {
+  const url = new URL(context.request.url);
+
+  if (url.searchParams.get("go-get") !== "1") {
+    return context.env.ASSETS.fetch(context.request);
+  }
+
+  const pkg = url.pathname.replace(/^\//, "").replace(/\/$/, "");
+  if (!pkg) {
+    return context.env.ASSETS.fetch(context.request);
+  }
+
+  const root = pkg.split("/")[0];
+  const repoURL = `https://github.com/${GH_USER}/${root}`;
+
+  const html = `<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="go-import" content="${DOMAIN}/${root} git ${repoURL}">
+<meta name="go-source" content="${DOMAIN}/${root} ${repoURL} ${repoURL}/tree/main{/dir} ${repoURL}/blob/main{/dir}/{file}#L{line}">
+<meta http-equiv="refresh" content="0; url=${repoURL}">
+</head>
+<body>
+Redirecting to <a href="${repoURL}">${repoURL}</a>
+</body>
+</html>`;
+
+  return new Response(html, {
+    headers: { "Content-Type": "text/html; charset=utf-8" },
+  });
+};


### PR DESCRIPTION
## Summary
- Adds a Pages Function (`functions/[[catchall]].ts`) that intercepts `?go-get=1` requests
- Returns the `go-import` meta tag for any package under `goodkind.io`, mapping to `github.com/agoodkind/<pkg>`
- All other requests pass through to static assets via `env.ASSETS.fetch()`
- Enables `go install goodkind.io/lm-review@latest` and any future Go modules

## Test plan
- [ ] Verify `curl "https://goodkind.io/lm-review?go-get=1"` returns go-import meta tag
- [ ] Verify homepage loads normally
- [ ] Verify `go run goodkind.io/lm-review/cmd/lm-review@latest version` works