### PR TITLE
Bump Go to 1.26.4 for net/textproto and crypto/x509 CVE patches

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module goodkind.io
 
-go 1.25.10
+go 1.26.4
 
 require (
 	github.com/a-h/templ v0.3.1020


### PR DESCRIPTION
Bump the go directive to 1.26.4 so the build toolchain includes the patched net/textproto (GO-2026-5039) and crypto/x509 (GO-2026-5037) standard library, which govulncheck flags on earlier 1.26.x/1.25.x.