### PR TITLE
Update Dependabot schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,4 +8,6 @@ updates:
   - package-ecosystem: "npm" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
-      interval: "weekly"
+      interval: "cron"
+      cronjob: 0 6 * * *
+      timezone: America/Los_Angeles


### PR DESCRIPTION
Switch Dependabot updates to an explicit once-daily cron schedule (`0 6 * * *`, `America/Los_Angeles`).